### PR TITLE
Give better advice for *print-length* setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,11 +371,11 @@ and it expects `clojure.pprint` to have been required already
 Accidentally printing large objects can be detrimental to your
 productivity. Clojure provides the `*print-length*` var which, if set,
 controls how many items of each collection the printer will print. You
-can supply a default value for REPL sessions via the `global-vars`
+can supply a default value for REPL sessions via the `repl-options`
 section of your Leiningen project's configuration.
 
 ```clojure
-:global-vars {*print-length* 100}
+:repl-options {:init (set! *print-length* 50)}
 ```
 
 ### ClojureScript usage


### PR DESCRIPTION
The README.md suggested that it would be a good idea to globally set `*print-length*` through the `:global-vars` key.  I followed the advice and have been bitten by that several times, because a non-`nil` `*print-length*` setting can cause several libraries (for example alembic or anything clojurescript related) to be incorrectly compiled.  In theory, everyone should make sure that the printer related dynamic variables are in a sane state when relying on the printer output to be something specific, but in practice this is hard to do, also because there is no macro like CL's `with-standard-io-syntax` that binds all printer dynamic variables to a sane state.

This PR updates README.md so that it suggests using `:repl-options` instead of `:global-vars`, which will not interfere with compilation of dependencies.
